### PR TITLE
rest controller for generating app

### DIFF
--- a/src/main/java/org/jbpm/bootstrap/service/controllers/IndexController.java
+++ b/src/main/java/org/jbpm/bootstrap/service/controllers/IndexController.java
@@ -15,34 +15,20 @@
  */
 package org.jbpm.bootstrap.service.controllers;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
-import javax.mail.internet.MimeUtility;
-
-import org.apache.commons.io.IOUtils;
 import org.jbpm.bootstrap.model.Project;
+import org.jbpm.bootstrap.service.util.BuildComponent;
 import org.jbpm.services.api.ProcessService;
 import org.jbpm.services.api.admin.ProcessInstanceAdminService;
-import org.kie.api.runtime.query.QueryContext;
-import org.kie.internal.runtime.error.ExecutionError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.util.FileSystemUtils;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -54,26 +40,20 @@ public class IndexController {
 
     private static final Logger logger = LoggerFactory.getLogger(IndexController.class);
 
-    private static final String CONTAINER_ID = "jbpm-bootstrap-kjar";
-    private static final String PROCESS_ID = "GenerateProject";
-
-    private static final String DEFAULT_VERSION = "7.15.0.Final";
-    private static final String KIE_VERSION = System.getProperty("org.kie.version", DEFAULT_VERSION);
-    private static final String MVN_SETTINGS = System.getProperty("kie.maven.settings.custom");
-
-    private File parent = new File(System.getProperty("java.io.tmpdir"));
-
     @Autowired
     private ProcessService processService;
 
     @Autowired
     ProcessInstanceAdminService processInstanceAdminService;
 
+    @Autowired
+    BuildComponent buildComponent;
+
     @GetMapping("/")
     public String showIndex(Model model) {
         return "index";
     }
-    
+
     @GetMapping("/reports")
     public String showReports(Model model) {
         return "reports";
@@ -87,118 +67,15 @@ public class IndexController {
     @PostMapping(value = "/", produces = {"application/octet-stream"})
     public @ResponseBody
     ResponseEntity<?> buildApp(@ModelAttribute Project project) throws Exception {
+        logger.info("Received request for generating application for project {}",
+                    project);
+
         if (project == null) {
             logger.error("Project is missing");
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
 
-        if(project.getOptions() == null) {
-            project.setOptions(Arrays.asList("kjar", "model", "service"));
-        }
-
-        if(project.getCapabilities() == null) {
-            project.setCapabilities(Arrays.asList("bpm"));
-        }
-
-        if(project.getName() == null || project.getName().length() < 1) {
-            project.setName("business-application");
-        }
-        
-        if(project.getPackageName() == null || project.getPackageName().length() < 1) {
-            project.setPackageName("com.company");
-        }
-
-        if(project.getVersion() == null || project.getVersion().length() < 1) {
-            project.setVersion(DEFAULT_VERSION);
-        }
-
-        logger.info("Received request for generating application for project {}",
-                    project);
-        String baseFileName = project.getName() + ".zip";
-
-        String fileName = null;
-        FileInputStream input;
-        File generatedProject = null;
-        try {
-            File tempFolder = new File(parent,
-                                       UUID.randomUUID().toString());
-            project.setLocation(tempFolder.getAbsolutePath());
-            logger.info("Location for the generated project is {}, final file name of the generated project is {}",
-                        project.getLocation(),
-                        fileName);
-            fileName = MimeUtility.encodeWord(baseFileName,
-                                              "utf-8",
-                                              "Q");
-
-            long timestamp = System.currentTimeMillis();
-            logger.info("About to start new process with container {} and process id {}",
-                        CONTAINER_ID,
-                        PROCESS_ID);
-
-            String kjarSettings = "";
-            if (project.getOptions().contains("kjar")) {
-                kjarSettings = "-DkjarGroupId=" + project.getPackageName() + " -DkjarArtifactId=" + project.getName() + "-kjar -DkjarVersion=1.0-SNAPSHOT";
-            }
-            if (project.getOptions().contains("dkjar")) {
-                kjarSettings = "-DkjarGroupId=" + project.getPackageName() + " -DkjarArtifactId=" + project.getName() + "-kjar -DkjarVersion=1.0-SNAPSHOT -DruntimeStrategy=PER_CASE";
-            }
-
-            String mavenSettings = "";
-            if (MVN_SETTINGS != null) {
-                mavenSettings = "-s " + MVN_SETTINGS;
-            }
-
-            Map<String, Object> params = new HashMap<>();
-            params.put("project",
-                       project);
-            params.put("projectSetup",
-                       resolveApplicationType(project));
-            params.put("kjarSettings",
-                       kjarSettings);
-            params.put("kieVersion",
-                       KIE_VERSION);
-            params.put("projectVersion",
-                    project.getVersion());
-            params.put("projectOptions",
-                    project.getOptions().stream().collect(Collectors.joining(",")));
-            params.put("mavenSettings",
-                    mavenSettings);
-            long processInstanceId = processService.startProcess(CONTAINER_ID,
-                                                                 PROCESS_ID,
-                                                                 params);
-
-            generatedProject = new File(tempFolder,
-                                        fileName);
-            waitForGeneratedProject(new File(tempFolder, project.getName() + ".marker"), processInstanceId);
-
-            logger.info("Project generation via process with instance id {} done in {} ms",
-                        processInstanceId,
-                        (System.currentTimeMillis() - timestamp));
-            input = new FileInputStream(generatedProject);
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.add("Content-Disposition",
-                        "attachment; filename=\"" + fileName + "\"");
-
-            ResponseEntity<byte[]> response = new ResponseEntity<byte[]>(
-                    IOUtils.toByteArray(input),
-                    headers,
-                    org.springframework.http.HttpStatus.OK);
-
-            return response;
-        } catch (Exception e) {
-            logger.error("Error when generating project",
-                         e);
-            throw new Exception(e.getMessage());
-        } finally {
-
-            if (generatedProject != null) {
-                boolean deleted = FileSystemUtils.deleteRecursively(generatedProject.getParentFile());
-                logger.info("Project archive {} and temp files deleted ({})",
-                            generatedProject,
-                            deleted);
-            }
-        }
+        return buildComponent.buildApp(project, true);
     }
 
     @GetMapping("/generatingmodal")
@@ -206,64 +83,16 @@ public class IndexController {
         return "fragments :: generatingmodal";
     }
 
-    protected String resolveApplicationType(Project project) {
-        if (project.getCapabilities().contains("brm")) {
-            return "brm";
-        } else if (project.getCapabilities().contains("planner")) {
-            return "planner";
-        } else {
-            return "bpm";
-        }
-    }
-
-    protected void waitForGeneratedProject(File generatedProject, long processInstanceId) throws Exception {
-        // check errors before we begin
-        checkProcessInstanceErrors(processInstanceId);
-
-        long totalWaitTime = 0;
-        int i = 0;
-        while (true) {
-
-            if (!generatedProject.exists()) {
-                Thread.sleep(200);
-                totalWaitTime += 200;
-
-                i++;
-                // every 4 seconds check errors again
-                if (i > 0 && (i % 20 == 0)) {
-                    checkProcessInstanceErrors(processInstanceId);
-                }
-
-                if (totalWaitTime > 60000) {
-                    throw new RuntimeException("Timeout while waiting for generated project");
-                }
-
-                continue;
-            }
-
-            return;
-        }
-
-    }
-
-    protected void checkProcessInstanceErrors(long processInstanceId) throws Exception {
-        List<ExecutionError> executionErrors =  processInstanceAdminService.getErrorsByProcessInstanceId(processInstanceId, true, new QueryContext());
-        if(executionErrors !=null && executionErrors.size() > 0) {
-            String errorString = executionErrors.stream()
-                    .map(i -> i.toString())
-                    .collect(Collectors.joining("\n "));
-
-            throw new Exception(errorString);
-        }
-    }
-
     @ExceptionHandler(Exception.class)
-    public String exception(final Exception e, final Model model) {
+    public String exception(final Exception e,
+                            final Model model) {
         StringWriter errors = new StringWriter();
         e.printStackTrace(new PrintWriter(errors));
-        model.addAttribute("stacktrace", errors.toString());
+        model.addAttribute("stacktrace",
+                           errors.toString());
         String errorMessage = (e != null ? e.getMessage() : "Unknown error");
-        model.addAttribute("errorMessage", errorMessage);
+        model.addAttribute("errorMessage",
+                           errorMessage);
         return "error";
     }
 }

--- a/src/main/java/org/jbpm/bootstrap/service/controllers/RestGenController.java
+++ b/src/main/java/org/jbpm/bootstrap/service/controllers/RestGenController.java
@@ -1,0 +1,66 @@
+package org.jbpm.bootstrap.service.controllers;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.jbpm.bootstrap.model.Project;
+import org.jbpm.bootstrap.service.util.BuildComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RestGenController {
+
+    private static final Logger logger = LoggerFactory.getLogger(RestGenController.class);
+
+    @Autowired
+    BuildComponent buildComponent;
+
+    @PostMapping(value = "/gen",
+            produces = {"application/octet-stream"},
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public ResponseEntity<?> buildApp(@RequestBody Map<String, Object> body) throws Exception {
+
+        Project project = new Project();
+        List<String> options = (List) body.get("options");
+        String capabilities = (String) body.get("capabilities");
+        String name = (String) body.get("name");
+        String packageName = (String) body.get("packagename");
+        String version = (String) body.get("version");
+
+        if (options != null) {
+            project.setOptions(options);
+        }
+
+        if (capabilities != null && capabilities.length() > 0) {
+            project.setCapabilities(Arrays.asList(capabilities.split("\\s*,\\s*")));
+        }
+
+        if (name != null && name.length() > 0) {
+            project.setName(name);
+        }
+
+        if (packageName != null || packageName.length() > 0) {
+            project.setPackageName(packageName);
+        }
+
+        if (version != null || version.length() > 0) {
+            project.setVersion(version);
+        }
+
+        logger.info("Received request for generating application for project {}",
+                    project);
+
+        return buildComponent.buildApp(project,
+                                       false);
+    }
+}

--- a/src/main/java/org/jbpm/bootstrap/service/security/BootstrapWebSecurityConfig.java
+++ b/src/main/java/org/jbpm/bootstrap/service/security/BootstrapWebSecurityConfig.java
@@ -30,6 +30,7 @@ public class BootstrapWebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
 		http
+        .headers().frameOptions().disable().and()
         .csrf().disable()
         .authorizeRequests()
             .regexMatchers("/rest/server/*").authenticated()

--- a/src/main/java/org/jbpm/bootstrap/service/util/BuildComponent.java
+++ b/src/main/java/org/jbpm/bootstrap/service/util/BuildComponent.java
@@ -1,0 +1,228 @@
+package org.jbpm.bootstrap.service.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.mail.internet.MimeUtility;
+
+import org.apache.commons.io.IOUtils;
+import org.jbpm.bootstrap.model.Project;
+import org.jbpm.services.api.ProcessService;
+import org.jbpm.services.api.admin.ProcessInstanceAdminService;
+import org.kie.api.runtime.query.QueryContext;
+import org.kie.internal.runtime.error.ExecutionError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.FileSystemUtils;
+
+@Component
+public class BuildComponent {
+
+    private static final Logger logger = LoggerFactory.getLogger(BuildComponent.class);
+    private File parent = new File(System.getProperty("java.io.tmpdir"));
+
+    private static final String CONTAINER_ID = "jbpm-bootstrap-kjar";
+    private static final String PROCESS_ID = "GenerateProject";
+
+    private static final String DEFAULT_VERSION = "7.15.0.Final";
+    private static final String KIE_VERSION = System.getProperty("org.kie.version",
+                                                                 DEFAULT_VERSION);
+    private static final String MVN_SETTINGS = System.getProperty("kie.maven.settings.custom");
+
+    @Autowired
+    private ProcessService processService;
+
+    @Autowired
+    ProcessInstanceAdminService processInstanceAdminService;
+
+    public ResponseEntity<byte[]> buildApp(Project project, boolean isWeb) throws Exception {
+        logger.info("Received request for generating application for project {}",
+                    project);
+
+        project = setDefaultsIfNotExist(project);
+
+        String baseFileName = project.getName() + ".zip";
+
+        String fileName = null;
+        FileInputStream input;
+        File generatedProject = null;
+        try {
+            File tempFolder = new File(parent,
+                                       UUID.randomUUID().toString());
+            project.setLocation(tempFolder.getAbsolutePath());
+            logger.info("Location for the generated project is {}, final file name of the generated project is {}",
+                        project.getLocation(),
+                        fileName);
+            fileName = MimeUtility.encodeWord(baseFileName,
+                                              "utf-8",
+                                              "Q");
+
+            long timestamp = System.currentTimeMillis();
+            logger.info("About to start new process with container {} and process id {}",
+                        CONTAINER_ID,
+                        PROCESS_ID);
+
+            String kjarSettings = "";
+            if (project.getOptions().contains("kjar")) {
+                kjarSettings = "-DkjarGroupId=" + project.getPackageName() + " -DkjarArtifactId=" + project.getName() + "-kjar -DkjarVersion=1.0-SNAPSHOT";
+            }
+            if (project.getOptions().contains("dkjar")) {
+                kjarSettings = "-DkjarGroupId=" + project.getPackageName() + " -DkjarArtifactId=" + project.getName() + "-kjar -DkjarVersion=1.0-SNAPSHOT -DruntimeStrategy=PER_CASE";
+            }
+
+            String mavenSettings = "";
+            if (MVN_SETTINGS != null) {
+                mavenSettings = "-s " + MVN_SETTINGS;
+            }
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("project",
+                       project);
+            params.put("projectSetup",
+                       resolveApplicationType(project));
+            params.put("kjarSettings",
+                       kjarSettings);
+            params.put("kieVersion",
+                       KIE_VERSION);
+            params.put("projectVersion",
+                       project.getVersion());
+            params.put("projectOptions",
+                       project.getOptions().stream().collect(Collectors.joining(",")));
+            params.put("mavenSettings",
+                       mavenSettings);
+            long processInstanceId = processService.startProcess(CONTAINER_ID,
+                                                                 PROCESS_ID,
+                                                                 params);
+
+            generatedProject = new File(tempFolder,
+                                        fileName);
+            waitForGeneratedProject(new File(tempFolder,
+                                             project.getName() + ".marker"),
+                                    processInstanceId);
+
+            logger.info("Project generation via process with instance id {} done in {} ms",
+                        processInstanceId,
+                        (System.currentTimeMillis() - timestamp));
+            input = new FileInputStream(generatedProject);
+
+            HttpHeaders headers = new HttpHeaders();
+
+            if(isWeb) {
+                headers.add("Content-Disposition",
+                            "attachment; filename=\"" + fileName + "\"");
+            }
+
+            ResponseEntity<byte[]> response =  new ResponseEntity<byte[]>(
+                    IOUtils.toByteArray(input),
+                    headers,
+                    org.springframework.http.HttpStatus.OK);
+
+            return response;
+
+        } catch (Exception e) {
+            logger.error("Error when generating project",
+                         e);
+            throw new Exception(e.getMessage());
+        } finally {
+
+            if (generatedProject != null) {
+                boolean deleted = FileSystemUtils.deleteRecursively(generatedProject.getParentFile());
+                logger.info("Project archive {} and temp files deleted ({})",
+                            generatedProject,
+                            deleted);
+            }
+        }
+    }
+
+    public String getDefaultVersion() {
+        return DEFAULT_VERSION;
+    }
+
+    public Project setDefaultsIfNotExist(Project project) {
+        if (project.getOptions() == null) {
+            project.setOptions(Arrays.asList("kjar",
+                                             "model",
+                                             "service"));
+        }
+
+        if (project.getCapabilities() == null) {
+            project.setCapabilities(Arrays.asList("bpm"));
+        }
+
+        if (project.getName() == null || project.getName().length() < 1) {
+            project.setName("business-application");
+        }
+
+        if (project.getPackageName() == null || project.getPackageName().length() < 1) {
+            project.setPackageName("com.company");
+        }
+
+        if (project.getVersion() == null || project.getVersion().length() < 1) {
+            project.setVersion(DEFAULT_VERSION);
+        }
+
+        return project;
+    }
+
+    protected String resolveApplicationType(Project project) {
+        if (project.getCapabilities().contains("brm")) {
+            return "brm";
+        } else if (project.getCapabilities().contains("planner")) {
+            return "planner";
+        } else {
+            return "bpm";
+        }
+    }
+
+    protected void waitForGeneratedProject(File generatedProject,
+                                           long processInstanceId) throws Exception {
+        // check errors before we begin
+        checkProcessInstanceErrors(processInstanceId);
+
+        long totalWaitTime = 0;
+        int i = 0;
+        while (true) {
+
+            if (!generatedProject.exists()) {
+                Thread.sleep(200);
+                totalWaitTime += 200;
+
+                i++;
+                // every 4 seconds check errors again
+                if (i > 0 && (i % 20 == 0)) {
+                    checkProcessInstanceErrors(processInstanceId);
+                }
+
+                if (totalWaitTime > 60000) {
+                    throw new RuntimeException("Timeout while waiting for generated project");
+                }
+
+                continue;
+            }
+
+            return;
+        }
+    }
+
+    protected void checkProcessInstanceErrors(long processInstanceId) throws Exception {
+        List<ExecutionError> executionErrors = processInstanceAdminService.getErrorsByProcessInstanceId(processInstanceId,
+                                                                                                        true,
+                                                                                                        new QueryContext());
+        if (executionErrors != null && executionErrors.size() > 0) {
+            String errorString = executionErrors.stream()
+                    .map(i -> i.toString())
+                    .collect(Collectors.joining("\n "));
+
+            throw new Exception(errorString);
+        }
+    }
+}


### PR DESCRIPTION
adds rest controller under /gen which can be used in future for IDEs and generation apps to use this service

to make request set headers:
Content-Type to application/json
Accept  to application/octet-stream

and body is a json string, for example: 
```
{ 
  capabilities: 'bpm',
  packagename: 'com.company',
  name: 'business-application',
  version: '',
  options: [ 'kjar', 'model', 'service' ] 
}
```