### PR TITLE
metrics counts for web/rest generations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/org/jbpm/bootstrap/service/rest/ReportResource.java
+++ b/src/main/java/org/jbpm/bootstrap/service/rest/ReportResource.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.actuate.metrics.buffer.BufferMetricReader;
 
 @Path("reports")
 public class ReportResource {
@@ -32,6 +33,9 @@ public class ReportResource {
     
     @Autowired
     private QueryService queryService;
+
+    @Autowired
+    private BufferMetricReader metricReader;
     
     @GET
     @Path("stats")
@@ -194,6 +198,36 @@ public class ReportResource {
                 .type(MediaType.APPLICATION_JSON_TYPE)
                 .entity(mapper.writeValueAsString(byOptions))
                 .build();
+        } catch (Exception e) {
+            logger.error("Unexepcted error while collecting report by version", e);
+            return Response.serverError().entity(e.getMessage()).build();
+        }
+    }
+
+    @GET
+    @Path("restgencount")
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public Response getRestGenCount() {
+        try {
+            return Response.ok()
+                    .type(MediaType.APPLICATION_JSON_TYPE)
+                    .entity(mapper.writeValueAsString(metricReader.findOne("counter.rest.generation.success")))
+                    .build();
+        } catch (Exception e) {
+            logger.error("Unexepcted error while collecting report by version", e);
+            return Response.serverError().entity(e.getMessage()).build();
+        }
+    }
+
+    @GET
+    @Path("webgencount")
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public Response getWebGenCount() {
+        try {
+            return Response.ok()
+                    .type(MediaType.APPLICATION_JSON_TYPE)
+                    .entity(mapper.writeValueAsString(metricReader.findOne("counter.web.generation.success")))
+                    .build();
         } catch (Exception e) {
             logger.error("Unexepcted error while collecting report by version", e);
             return Response.serverError().entity(e.getMessage()).build();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,3 +48,11 @@ spring.jta.narayana.transaction-manager-id=1
 
 #thymeleaf configuration
 spring.thymeleaf.mode=LEGACYHTML5
+
+#actuator configuration
+management.contextPath: /actuator
+management.security.enabled=false
+
+# Pretty-print JSON responses
+spring.jackson.serialization.indent_output=true
+

--- a/src/main/resources/templates/reports.html
+++ b/src/main/resources/templates/reports.html
@@ -63,7 +63,6 @@
 		</div>
 		<br />
 
-
 		<nav class="navbar navbar-light bg-light">
 			<div class="col-sm-12 text-center jbpm-card-body">
 				<h2>
@@ -95,6 +94,38 @@
 			</div>
 
 		</div>
+		<br />
+		<nav class="navbar navbar-light bg-light">
+			<div class="col-sm-12 text-center jbpm-card-body">
+				<h2>
+					<strong>Counts</strong> for app generation since last restart
+				</h2>
+			</div>
+		</nav>
+		<br/>
+		<div class="row justify-content-center" style="width: 70%; margin-left: 15%">
+			<div class="col-sm-5">
+				<div class="card text-center" style="width: 25rem;">
+					<div class="card-header">Web generations</div>
+					<div class="card-body">
+						<p class="card-text text-center">
+							<b><span id="totalWebSinceRestart"></span></b>
+						</p>
+					</div>
+				</div>
+			</div>
+			<div class="col-sm-5">
+				<div class="card text-center" style="width: 25rem;">
+					<div class="card-header">Rest generations</div>
+					<div class="card-body">
+						<p class="card-text text-center">
+							<b><span id="totalRestSinceRestart"></span></b>
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+		<br />
 		<br />
 		<br />
 		<footer class="page-footer font-small jbpmfooter text-center">
@@ -229,6 +260,32 @@
 								loadPieOptionsChart(data);
 
 							});
+
+                            $.get(window.location.protocol + "//"
+                                    + window.location.host
+                                    + "/rest/reports/webgencount", function(data,
+                                    status) {
+
+                                if(data == null) {
+                                    $('#totalWebSinceRestart').text("0");
+								} else {
+                                    $('#totalWebSinceRestart').text(data.value);
+								}
+
+                            });
+
+                            $.get(window.location.protocol + "//"
+                                    + window.location.host
+                                    + "/rest/reports/restgencount", function(data,
+                                    status) {
+
+                                if(data == null) {
+                                    $('#totalRestSinceRestart').text("0");
+                                } else {
+                                    $('#totalRestSinceRestart').text(data.value);
+                                }
+
+                            });
 
 						});
 	</script>


### PR DESCRIPTION
* adds actuator spring boot starter
* adds custom counters for metrics  (counter.web.generation.success, counter.rest.generation.success,counter.web.generation.failure, counter.rest.generation.failure)
* adds two endpoints for /rest/reports which query these custom counters and can be displayed on reports page:

<img width="1299" alt="screen shot 2019-01-15 at 9 13 10 pm" src="https://user-images.githubusercontent.com/119422/51222143-69636600-190a-11e9-996c-683a1baf5c9c.png">

This will allow us to count (via spring boot actuator metrics) the number of web vs number of rest generations .. and can count a little how many generations were done via jba-cli)
In future we can see to persist this additional counts. For now it will count until app restarts (currently in-memory only)

The counters can also be seen with start.jbpm.org/actuator/metrics:

<img width="505" alt="screen shot 2019-01-15 at 9 16 29 pm" src="https://user-images.githubusercontent.com/119422/51222234-d840bf00-190a-11e9-893f-b3ee58ecd793.png">
