### PR TITLE
Updating the url from business central in dev config file

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -12,7 +12,7 @@ kieserver.serverId=bootstrap-jbpm-dev
 kieserver.serverName=BootstrapJBPM Development
 kieserver.restContextPath=/rest
 kieserver.location=http://localhost:8090/rest/server
-kieserver.controllers=http://localhost:8080/jbpm-console/rest/controller
+kieserver.controllers=http://localhost:8080/business-central/rest/controller
 
 #jbpm configuration
 jbpm.executor.enabled=true


### PR DESCRIPTION
We don't have _jbpm-console_ URL anymore. This PR updates this default config on the src/main/resources/application-dev.properties file for the generated projects.