### PR TITLE
Migrating from fabric8 to jkube plugin

### DIFF
--- a/openshift.Dockerfile
+++ b/openshift.Dockerfile
@@ -1,0 +1,15 @@
+# USED AS REFERENCE ONLY
+# run from parent dir:
+# docker build --tag quay.io/bootstrapjbpm/start-jbpm:latest -f jbpm-bootstrap-service/src/main/docker/openshift.Dockerfile .
+FROM fabric8/java-centos-openjdk8-jre
+
+USER jboss
+
+ENV JAVA_OPTIONS "-Dorg.kie.version=7.RELEASE -Dspring.profiles.active=openshift -Dkie.maven.settings.custom=/opt/jboss/.m2/settings.xml"
+
+RUN mkdir -p /opt/jboss/.m2/repository
+
+COPY --chown=jboss jbpm-bootstrap-service/target/*.jar /deployments
+COPY --chown=jboss jbpm-bootstrap-service/bootstrap-jbpm.xml /deployments
+COPY --chown=jboss jbpm-bootstrap-service/src/main/docker/settings.xml /opt/jboss/.m2
+COPY --chown=jboss jbpm-bootstrap-kjar/target/local-repository/maven /opt/jboss/.m2/repository

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
 
       <properties>
         <jkube.mode>openshift</jkube.mode>
-        <local.maven.path>../jbpm-bootstrap-kjar/target/local-repository/maven<</local.maven.path>
+        <local.maven.path>../jbpm-bootstrap-kjar/target/local-repository/maven</local.maven.path>
       </properties>
 
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
       </activation>
 
       <properties>
-        <jkube.mode>kubernetes</jkube.mode>
+        <jkube.mode>openshift</jkube.mode>
       </properties>
 
       <build>
@@ -218,7 +218,7 @@
                 <image>
                   <name>jbpm/${project.artifactId}:${project.version}</name>
                   <build>
-                    <from>fabric8/java-jboss-openjdk8-jdk</from>
+                    <from>fabric8/s2i-java:latest</from>
                     <assembly>
                       <targetDir>/</targetDir>
                       <inline>

--- a/pom.xml
+++ b/pom.xml
@@ -214,11 +214,12 @@
             <version>${jkube.version}</version>
             <configuration>
               <verbose>false</verbose>
+              <buildStrategy>docker</buildStrategy>
               <images>
                 <image>
                   <name>jbpm/${project.artifactId}:${project.version}</name>
                   <build>
-                    <from>fabric8/s2i-java:latest</from>
+                    <from>fabric8/java-centos-openjdk8-jre</from>
                     <assembly>
                       <targetDir>/</targetDir>
                       <inline>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     
     <kie.version>7.52.0.Final</kie.version>
     <org.jbpm.start.model.version>1.0.0</org.jbpm.start.model.version>
+    <jkube.version>1.2.0</jkube.version>
   </properties>
 
   <dependencies>
@@ -126,15 +127,15 @@
       </activation>
 
       <properties>
-        <fabric8.mode>kubernetes</fabric8.mode>
+        <jkube.mode>kubernetes</jkube.mode>
       </properties>
 
       <build>
         <plugins>
           <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>fabric8-maven-plugin</artifactId>
-            <version>3.5.40</version>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>kubernetes-maven-plugin</artifactId>
+            <version>${jkube.version}</version>
             <configuration>
               <verbose>false</verbose>
               <images>
@@ -157,17 +158,19 @@
                             <destName>bootstrap-jbpm.xml</destName>
                           </file>
                         </files>
-                        <fileSet>
-                          <directory>src/main/docker</directory>
-                          <outputDirectory>opt/jboss/.m2</outputDirectory>
-                          <includes>
-                            <include>settings.xml</include>
-                          </includes>
-                        </fileSet>
-                        <fileSet>
-                          <directory>../jbpm-bootstrap-kjar/target/local-repository/maven</directory>
-                          <outputDirectory>opt/jboss/.m2/repository</outputDirectory>
-                        </fileSet>
+                        <fileSets>
+                          <fileSet>
+                            <directory>src/main/docker</directory>
+                            <outputDirectory>opt/jboss/.m2</outputDirectory>
+                            <includes>
+                              <include>settings.xml</include>
+                            </includes>
+                          </fileSet>
+                          <fileSet>
+                            <directory>../jbpm-bootstrap-kjar/target/local-repository/maven</directory>
+                            <outputDirectory>opt/jboss/.m2/repository</outputDirectory>
+                          </fileSet>
+                        </fileSets>
                       </inline>
                       <user>jboss:jboss:jboss</user>
                     </assembly>
@@ -200,15 +203,15 @@
       </activation>
 
       <properties>
-        <fabric8.mode>kubernetes</fabric8.mode>
+        <jkube.mode>kubernetes</jkube.mode>
       </properties>
 
       <build>
         <plugins>
           <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>fabric8-maven-plugin</artifactId>
-            <version>3.5.40</version>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>openshift-maven-plugin</artifactId>
+            <version>${jkube.version}</version>
             <configuration>
               <verbose>false</verbose>
               <images>
@@ -231,17 +234,19 @@
                             <destName>bootstrap-jbpm.xml</destName>
                           </file>
                         </files>
-                        <fileSet>
-                          <directory>src/main/docker</directory>
-                          <outputDirectory>opt/jboss/.m2</outputDirectory>
-                          <includes>
-                            <include>settings.xml</include>
-                          </includes>
-                        </fileSet>
-                        <fileSet>
-                          <directory>../jbpm-bootstrap-kjar/target/local-repository/maven</directory>
-                          <outputDirectory>opt/jboss/.m2/repository</outputDirectory>
-                        </fileSet>
+                        <fileSets>
+                          <fileSet>
+                            <directory>src/main/docker</directory>
+                            <outputDirectory>opt/jboss/.m2</outputDirectory>
+                            <includes>
+                              <include>settings.xml</include>
+                            </includes>
+                          </fileSet>
+                          <fileSet>
+                            <directory>../jbpm-bootstrap-kjar/target/local-repository/maven</directory>
+                            <outputDirectory>opt/jboss/.m2/repository</outputDirectory>
+                          </fileSet>
+                        </fileSets>
                       </inline>
                       <user>jboss:jboss:jboss</user>
                     </assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@
 
       <properties>
         <jkube.mode>openshift</jkube.mode>
+        <local.maven.path>../jbpm-bootstrap-kjar/target/local-repository/maven<</local.maven.path>
       </properties>
 
       <build>
@@ -244,7 +245,7 @@
                             </includes>
                           </fileSet>
                           <fileSet>
-                            <directory>../jbpm-bootstrap-kjar/target/local-repository/maven</directory>
+                            <directory>${local.maven.path}</directory>
                             <outputDirectory>opt/jboss/.m2/repository</outputDirectory>
                           </fileSet>
                         </fileSets>

--- a/src/main/jkube/deployment.yaml
+++ b/src/main/jkube/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: jbpm-bootstrap-service
+  name: jbpm-bootstrap-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jbpm-bootstrap-service
+  template:
+    metadata:
+      labels:
+        app: jbpm-bootstrap-service
+    spec:
+      containers:
+        - name: jbpm-bootstrap-service
+          image: jbpm-bootstrap-service:1.0.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8090
+              protocol: TCP
+            - containerPort: 8443
+              protocol: TCP
+            - containerPort: 8778
+              protocol: TCP
+            - containerPort: 9779
+              protocol: TCP
+          resources:
+            requests:
+              memory: "1024Mi"
+              cpu: "500m"
+            limits:
+              memory: "2048Mi"
+              cpu: "1000m"
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - jbpm-bootstrap-service
+        from:
+          kind: ImageStreamTag
+          name: 'jbpm-bootstrap-service:1.0.0'
+      type: ImageChange
+    - type: ConfigChange

--- a/src/main/jkube/route.yaml
+++ b/src/main/jkube/route.yaml
@@ -1,0 +1,15 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: jbpm-bootstrap-service
+spec:
+  port:
+    targetPort: https
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: passthrough
+  to:
+    kind: Service
+    name: jbpm-bootstrap-service
+    weight: 100
+  wildcardPolicy: None

--- a/src/main/jkube/service.yaml
+++ b/src/main/jkube/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jbpm-bootstrap-service
+  labels:
+    app: jbpm-bootstrap-service
+spec:
+  ports:
+    - name: https
+      port: 8443
+  selector:
+    app: jbpm-bootstrap-service


### PR DESCRIPTION
Fabric8 is deprecated, this way we keep the same functionality with the new plugin.

To generate the Docker image locally (using Docker daemon), one must run:

```
mvn clean install -Pdocker
```

To build the application directly in the cluster, use:

```
mvn clean install -Popenshift
```

The latter will use OpenShift s2i mechanism to build the app. @msmagnanijr I guess you can use this one and leverage the generated ImageStream to continue deploying the application with Tekton.